### PR TITLE
Use GitHub metadata locally with jekyll-github-metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "github-pages"
+gem "jekyll-github-metadata"

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 markdown: kramdown
+repository: jdennes/jdennes.github.io
 gems:
 - jemoji
+- jekyll-github-metadata

--- a/script/server
+++ b/script/server
@@ -1,1 +1,1 @@
-bundle exec jekyll serve --watch --safe
+bundle exec jekyll serve --watch


### PR DESCRIPTION
Just testing https://github.com/jekyll/github-metadata when running locally.